### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   portfoli.go:
-    image: gchr.io/bossm8/portfoli-go:latest
+    image: ghcr.io/bossm8/portfoli-go:latest
     container_name: portfoli.go
     volumes:
       - ${PWD}/configs:/var/www/portfoli.go/configs:ro


### PR DESCRIPTION
Hi `bossm8/portfoli.go`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used - In some cases it's only a matter of wrongly tagged container images)
Please verify the changes made with this PR and check your documentation for similar typos.